### PR TITLE
Fix ETS extraction regex

### DIFF
--- a/app/extractores.py
+++ b/app/extractores.py
@@ -125,7 +125,13 @@ _PAT_GENERAL_ETS = {
 }
 
 _PAT_STATS_ETS = r'INSCRITOS:\s*(\d+)\s+APROBADOS:\s*(\d+)\s+REPROBADOS:\s*(\d+)\s+NO PRESENTARON:\s*(\d+)'
-_PAT_ESTUDIANTE_ETS = r'(\d{10})\s+([A-Z\s]+?)\s+(NP|[0-9]+)\s+\(([^)]+)\)\s+(\d+)'
+_PAT_ESTUDIANTE_ETS = (
+    r"(\d+)\s+"         # Numero de lista
+    r"(\d{10})\s+"     # Boleta
+    r"([A-ZÁÉÍÓÚÑáéíóúñ\s]+?)\s+"  # Nombre con posibles acentos
+    r"(NP|[0-9]+)\s+"   # Calificación o NP
+    r"\(([^)]+)\)"     # Texto entre paréntesis (opcional)
+)
 
 def _extraer_ets(texto: str) -> Tuple[Dict[str, Any], pd.DataFrame, Dict[str, int]]:
     encabezado: Dict[str, Any] = {}
@@ -152,8 +158,11 @@ def _extraer_ets(texto: str) -> Tuple[Dict[str, Any], pd.DataFrame, Dict[str, in
 
     # Estudiantes
     registros = []
-    for boleta, nombre, calif, _, num_lista in re.findall(_PAT_ESTUDIANTE_ETS, texto):
-        calif_val = calif if calif == "NP" else int(calif)
+    for num_lista, boleta, nombre, calif, _ in re.findall(_PAT_ESTUDIANTE_ETS, texto):
+        try:
+            calif_val = int(calif)
+        except ValueError:
+            calif_val = "NP"
         registros.append(
             {
                 "Boleta": boleta,

--- a/app/ver_dashboard.py
+++ b/app/ver_dashboard.py
@@ -132,8 +132,11 @@ def ver_dashboards():
     origines = ["ordinario", "extraordinario", "ets"]
     estatuses = ["Aprobado", "Reprobado", "NP"]
 
-    # Convertir a categóricos para asegurar que se incluyan todas las
-    # combinaciones posibles aun cuando no existan registros para alguna.
+    # Normalizar valores por si provienen con mayúsculas o espacios
+    df_bar["Origen"] = df_bar["Origen"].str.lower().str.strip()
+    df_bar["Estatus"] = df_bar["Estatus"].str.capitalize().str.strip()
+
+    # Convertir a categóricos para garantizar que aparezcan todas las barras
     df_bar["Origen"] = pd.Categorical(df_bar["Origen"], categories=origines, ordered=True)
     df_bar["Estatus"] = pd.Categorical(df_bar["Estatus"], categories=estatuses, ordered=True)
 


### PR DESCRIPTION
## Summary
- update ETS pattern to capture list number first and allow accents
- safely handle OCR errors when converting grades

## Testing
- `python -m pip install pandas` *(fails: Could not find a version that satisfies the requirement pandas)*

------
https://chatgpt.com/codex/tasks/task_e_6886fc71a56c832097de2811791edd76