### PR TITLE
Fix dashboard filter navigation

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,13 +25,17 @@ if estado["logueado"]:
     # === Usuario logueado ===
     st.success(f"Bienvenido, **{estado['nombre_usuario']}**")
 
-    # === Menú lateral ===
-    menu_actual = st.sidebar.radio("Menú", ["Crear nuevo dashboard", "Ver dashboards", "Cerrar sesión"])
-
     # === Redirección si se estableció desde otro módulo ===
     if estado.get("menu"):
-        menu_actual = estado["menu"]
+        st.session_state["menu_sidebar"] = estado["menu"]
         estado["menu"] = None  # Reiniciar el estado para futuras vistas
+
+    # === Menú lateral ===
+    menu_actual = st.sidebar.radio(
+        "Menú",
+        ["Crear nuevo dashboard", "Ver dashboards", "Cerrar sesión"],
+        key="menu_sidebar"
+    )
 
     if menu_actual == "Crear nuevo dashboard":
         from app.crear_dashboard import crear_dashboard

--- a/app/ver_dashboard.py
+++ b/app/ver_dashboard.py
@@ -22,7 +22,11 @@ def ver_dashboards():
     opciones = {
         f"{d.titulo_personalizado} ({d.materia.nombre_materia})": d.id_dashboard for d in dashboards
     }
-    seleccion = st.selectbox("Selecciona un dashboard", list(opciones.keys()))
+    seleccion = st.selectbox(
+        "Selecciona un dashboard",
+        list(opciones.keys()),
+        key="seleccion_dashboard"
+    )
 
     if not seleccion:
         return
@@ -71,8 +75,16 @@ def ver_dashboards():
     grupos = df_completo["Grupo"].unique().tolist()
     carreras = df_completo["Licenciatura"].unique().tolist()
 
-    grupo_sel = col1.selectbox("Filtrar por grupo", ["Todos"] + grupos)
-    carrera_sel = col2.selectbox("Filtrar por licenciatura", ["Todos"] + carreras)
+    grupo_sel = col1.selectbox(
+        "Filtrar por grupo",
+        ["Todos"] + grupos,
+        key="filtro_grupo"
+    )
+    carrera_sel = col2.selectbox(
+        "Filtrar por licenciatura",
+        ["Todos"] + carreras,
+        key="filtro_carrera"
+    )
 
     df_filtrado = df_completo.copy()
     if grupo_sel != "Todos":


### PR DESCRIPTION
## Summary
- keep sidebar selection stable when widgets rerun
- add unique keys for dashboard filters

## Testing
- `python -m py_compile app.py app/ver_dashboard.py`


------
https://chatgpt.com/codex/tasks/task_e_688715f32ce0832099d0876a427adca8